### PR TITLE
Add more logging, fixup README, and use more idiomatic Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,17 +1,3 @@
-[root]
-name = "jig-20-interface-http"
-version = "0.1.0"
-dependencies = [
- "clap 2.20.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "urlencoded 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "ansi_term"
 version = "0.9.0"
@@ -136,6 +122,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "itoa"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jig-20-interface-http"
+version = "0.1.0"
+dependencies = [
+ "clap 2.20.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mount 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "urlencoded 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For testing purposes, you can simply run the program directly.  However, this is
 
 To use with exclave, create `webserver.interface` in your exclave tests directory:
 
-````
+````ini
 [Interface]
 Name=Web Server
 Description=Runs a web server on port 3000

--- a/README.md
+++ b/README.md
@@ -1,23 +1,50 @@
-Jig-20 HTTP Interface
-=======================
+# Jig-20 HTTP Interface
 
 A web-based interface for the Jig-20 framework.
 
+## Usage
 
-Running
--------
+Build the program using cargo by running `cargo build --release`.
 
-Create webserver.interface in your jig-20 tests directory:
+Run the program by starting target/release/jig-20-interface-http.  You can specify a port with `--port`, and it defaults to port 3000.
 
- [Interface]
- Name=Web Server
- Description=Runs a web server on port 3000
- Format=text
- ExecStart=cargo run
- WorkingDirectory=../jig-20-interface-http/
+Create a website by adding files to `html/`.  These will be served up by the webserver.
 
+You interact with the server by performing GET requests:
 
-About
-------
+* `/current.json` - Returns a JSON object with the current tester state
+* `/log.json` - Returns a JSON array with all log events.  You can obtain a subset of logs by specifying "&start=" and "&end=".  For example, to get the 2nd and 3rd logs ever generated, GET `/log.json?start=2&end=3`
+* `/log/current.json` - Show logs for the current run (i.e. everything since START was pressed).  Also supports "&start=" and "&end="
+* `/log/previous.json` - Show logs for the previous run.  Also supports "&start=" and "&end="
+* `/stdin.txt` - Debug output of all text received on STDIN (if "-l" is specified).
+
+Additionally, you can make requests to exclave by performing GET requests to the following addresses:
+
+* `/truncate` - Truncate `log.json` and free associated memory.
+* `/start` - Issue a "Start" command to exclave.  Exclave will ignore `start` if a scenario is already running.
+* `/abort` - Abort the current scenario, if one is running.
+* `/tests` - Request a new list of tests from exclave -- the result will appear in `/current.json`
+* `/scenarios` - Request a new list of scenarios from exclave -- the result will appear in `/current.json`
+* `/scenario` - Request the current scenario from exclave -- the result will appear in `/current.json`
+* `/jig` - Request the current jig from exclave -- the result will appear in `/current.json`
+* `/hello` - Send the "HELLO" message to exclave, to identify this server
+* `/exit` - Shut down exclave and quit this web server
+
+## Running
+
+For testing purposes, you can simply run the program directly.  However, this is less useful without a server to generate CFTI messages.
+
+To use with exclave, create `webserver.interface` in your exclave tests directory:
+
+````
+[Interface]
+Name=Web Server
+Description=Runs a web server on port 3000
+Format=text
+ExecStart=jig-20-interface-http --port 3000
+WorkingDirectory=path-to-directory-containing-html-directory/
+````
+
+## About
 
 This interface uses the Common Factory Test Interface (CFTI) Interface-dialect.  It communicates with the server via its stdin and stdout.

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,13 +22,6 @@ use std::collections::HashMap;
 
 const SERVER_SIGNATURE: &'static str = "CFTI HTTP 1.0";
 
-macro_rules! println_stderr(
-    ($($arg:tt)*) => { {
-        let r = writeln!(&mut ::std::io::stderr(), $($arg)*);
-        r.expect("failed printing to stderr");
-    } }
-);
-
 #[derive(Clone, Debug)]
 enum OutgoingMessage {
     Hello(String),
@@ -298,19 +291,19 @@ fn stdin_describe(data_arc: &Arc<Mutex<InterfaceState>>, items: Vec<String>) {
         "test" => match field.as_str() {
             "name" => {data_arc.lock().unwrap().test_names.insert(name_lc, value);},
             "description" => {data_arc.lock().unwrap().test_descriptions.insert(name_lc, value);},
-            f => println_stderr!("Unrecognized field: {}", f),
+            f => eprintln!("Unrecognized field: {}", f),
         },
         "scenario" => match field.as_str() {
             "name" => {data_arc.lock().unwrap().scenario_names.insert(name_lc, value);},
             "description" => {data_arc.lock().unwrap().scenario_descriptions.insert(name_lc, value);},
-            f => println_stderr!("Unrecognized field: {}", f),
+            f => eprintln!("Unrecognized field: {}", f),
         },
         "jig" => match field.as_str() {
             "name" => {data_arc.lock().unwrap().jig_name = value;},
             "description" => {data_arc.lock().unwrap().jig_description = value;},
-            f => println_stderr!("Unrecognized field: {}", f),
+            f => eprintln!("Unrecognized field: {}", f),
         },
-        c => println_stderr!("Unrecognized class: {}", c),
+        c => eprintln!("Unrecognized class: {}", c),
     };
 }
 
@@ -323,7 +316,7 @@ fn stdin_monitor(data_arc: Arc<Mutex<InterfaceState>>, logs: Arc<Mutex<Vec<LogMe
         let line = cfti_unescape(line);
 
         let mut items: Vec<String> = line.split_whitespace().map(|x| x.to_string()).collect();
-        //println_stderr!("Got command: {:?}", items);
+        //eprintln!("Got command: {:?}", items);
         let verb = items[0].to_lowercase();
         items.remove(0);
 
@@ -361,7 +354,7 @@ fn stdin_monitor(data_arc: Arc<Mutex<InterfaceState>>, logs: Arc<Mutex<Vec<LogMe
             "finish" => {
                 let result = match items.remove(1).parse() {
                     Ok(val) => val,
-                    Err(e) => {println_stderr!("Unable to parse result: {:?}", e); 500},
+                    Err(e) => {eprintln!("Unable to parse result: {:?}", e); 500},
                 };
 
                 data_arc.lock().unwrap().scenario_state = match result {
@@ -407,7 +400,7 @@ fn stdin_monitor(data_arc: Arc<Mutex<InterfaceState>>, logs: Arc<Mutex<Vec<LogMe
                 });
             },
             "exit" => std::process::exit(0),
-            other => println_stderr!("Unrecognized command: {}", other),
+            other => eprintln!("Unrecognized command: {}", other),
         }
     }
 }


### PR DESCRIPTION
This patchset adds `/log/current.json` and `/log/previous.json`, which are two URLs that return the log results from both the current and past scenario run.

Additionally, it updates the README to document the server's API.

Finally, it uses more idiomatic Rust, such as keeping a ref around instead of doing state.lock().unwrap() everywhere.